### PR TITLE
Add Transactional Emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ AUTH0_FRONTEND_CLIENT_SECRET=secret-from-auth0
 AUTH0_BACKEND_CLIENT_ID=machine-to-machine-client-id-from-auth0
 AUTH0_BACKEND_CLIENT_SECRET=machine-to-machine-secret-from-auth0
 
+SENDGRID_API_KEY=sendgrid-api-key
+
 CORS_ORIGIN=*
 
 # Use this port to serve as the API for find-a-mentor (the FE)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/mongoose": "^6.1.2",
     "@nestjs/platform-express": "^6.0.0",
     "@nestjs/swagger": "^3.1.0",
+    "@sendgrid/mail": "^6.4.0",
     "class-transformer": "^0.2.3",
     "class-validator": "^0.9.1",
     "dotenv": "^8.0.0",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -19,6 +19,9 @@ const config = {
   },
   sendGrid: {
     API_KEY: process.env.SENDGRID_API_KEY,
+  },
+  email: {
+    FROM: 'Coding Coach <no-reply@mail.codingcoach.io>',
   }
 };
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -17,6 +17,9 @@ const config = {
       DOMAIN: process.env.AUTH0_DOMAIN,
     },
   },
+  sendGrid: {
+    API_KEY: process.env.SENDGRID_API_KEY,
+  }
 };
 
 export default config;

--- a/src/modules/email/email.module.ts
+++ b/src/modules/email/email.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { EmailService } from './email.service';
+
+@Module({
+  providers: [EmailService],
+  exports: [EmailService],
+})
+export class EmailModule {}

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -1,29 +1,24 @@
 import Config from '../../config';
 import * as sgMail from '@sendgrid/mail';
+import {SendData} from './interfaces/email.interface'
+import { Injectable } from '@nestjs/common';
 
 
 const defaults = {
     from: 'Coding Coach <no-reply@mail.codingcoach.io>',
 };
 
-// TODO: Convert this to a service.
-class EmailFacade {
+
+@Injectable
+class EmailProvider {
     constructor() {
         sgMail.setApiKey(Config.sendGrid.API_KEY);
     }
     
-    send(data: any) {
+    send(data: SendData) {
         const newData = Object.assign({}, defaults, data)
         return sgMail.send(newData);
     }
-    
 }
 
-// No point in instantiating this thing more than once, 
-// so it's safe to use a singleton here.  Also freeze the object
-// so it can't be abused later.  👀
-const emailClient = new EmailFacade()
-Object.freeze(emailClient)
-
-
-export default emailClient
+export default EmailProvider

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -9,10 +9,17 @@ const defaults = {
 };
 
 
-@Injectable
-class EmailProvider {
+@Injectable()
+export class EmailService {
     constructor() {
         sgMail.setApiKey(Config.sendGrid.API_KEY);
+    }
+
+    static TEMPLATE_IDS = {
+        WELCOME_MESSAGE: 'd-1434be390e1b4288b8011507f1c8d786',
+        MENTOR_APPLICATION_RECEIVED: 'd-bf78306901e747a7b3f92761b9884f2e',
+        MENTOR_APPLICATION_APPROVED: 'd-88dc20e5dd164510a32f659f9347824e',
+        MENTOR_APPLICATION_REJECTED: 'd-ad08366d02654587916a41bb3270afed',
     }
     
     send(data: SendData) {
@@ -20,5 +27,3 @@ class EmailProvider {
         return sgMail.send(newData);
     }
 }
-
-export default EmailProvider

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@nestjs/common';
 
 
 const defaults = {
-    from: 'Coding Coach <no-reply@mail.codingcoach.io>',
+    from: Config.email.FROM,
 };
 
 

--- a/src/modules/email/interfaces/email.interface.ts
+++ b/src/modules/email/interfaces/email.interface.ts
@@ -1,0 +1,4 @@
+export interface SendData {
+  to: String,
+  templateId: String,
+}

--- a/src/modules/mentors/mentors.controller.ts
+++ b/src/modules/mentors/mentors.controller.ts
@@ -140,7 +140,7 @@ export class MentorsController {
     if (applicationDto.status === Status.REJECTED) {
       templateId = EmailService.TEMPLATE_IDS.MENTOR_APPLICATION_REJECTED
     } else {
-      EmailService.TEMPLATE_IDS.MENTOR_APPLICATION_APPROVED
+templateId = EmailService.TEMPLATE_IDS.MENTOR_APPLICATION_APPROVED
     }
 
     const emailData = {

--- a/src/modules/mentors/mentors.controller.ts
+++ b/src/modules/mentors/mentors.controller.ts
@@ -86,6 +86,14 @@ export class MentorsController {
 
     await this.mentorsService.createApplication(applicationDto);
 
+    // TODO: Move this templateId into a constant
+    const emailData = {
+      to: user.email,
+      templateId: `d-bf78306901e747a7b3f92761b9884f2e`
+    };
+    
+    EmailClient.send(emailData)
+
     return {
       success: true,
     };
@@ -123,24 +131,18 @@ export class MentorsController {
       roles: [...user.roles, Role.MENTOR],
     });
     
-    this.usersService.update(userDto);
     
-    // TODO: Move this HTML into SendGrid's templating system
+    const res: any = await this.mentorsService.updateApplication(applicationDto);
+
+    this.usersService.update(userDto);
+
+    // TODO: Move these templateIds into a constant
     const emailData = {
       to: userDto.email,
-      subject: 'Welcome Aboard, Mentor!',
-      html: `<div style="font-family:Verdana,sans-serif;">
-        <h1>Welcome Aboard, Mentor!</h1>
-        <p style="margin:0 0 32px">Your request to become a mentor has been approved.</p>
-        <a href="https://mentors.codingcoach.io/" style="border-radius:4px;color:#fff;background:#00bc89;padding:12px 16px;text-decoration:none;">
-          SEE ALL MENTORS
-        </a>
-        </div>`
+      templateId: applicationDto.status === Status.REJECTED ? `d-ad08366d02654587916a41bb3270afed` : `d-88dc20e5dd164510a32f659f9347824e`
     };
     
     EmailClient.send(emailData)
-
-    const res: any = await this.mentorsService.updateApplication(applicationDto);
 
     return {
       success: res.ok === 1,

--- a/src/modules/mentors/mentors.controller.ts
+++ b/src/modules/mentors/mentors.controller.ts
@@ -8,6 +8,7 @@ import { ApplicationDto } from './dto/application.dto';
 import { User, Role } from '../users/interfaces/user.interface';
 import { Application, Status } from './interfaces/application.interface';
 import { UserDto } from '../users/dto/user.dto';
+import EmailClient from '../../utils/email-client'
 
 @ApiUseTags('/mentors')
 @Controller('mentors')
@@ -123,6 +124,22 @@ export class MentorsController {
     });
     
     this.usersService.update(userDto);
+    
+    // TODO: Move this HTML into SendGrid's templating system
+    const emailData = {
+      to: userDto.email,
+      subject: 'Welcome Aboard, Mentor!',
+      html: `<div style="font-family:Verdana,sans-serif;">
+        <h1>Welcome Aboard, Mentor!</h1>
+        <p style="margin:0 0 32px">Your request to become a mentor has been approved.</p>
+        <a href="https://mentors.codingcoach.io/" style="border-radius:4px;color:#fff;background:#00bc89;padding:12px 16px;text-decoration:none;">
+          SEE ALL MENTORS
+        </a>
+        </div>`
+    };
+    
+    EmailClient.send(emailData)
+
     const res: any = await this.mentorsService.updateApplication(applicationDto);
 
     return {

--- a/src/modules/mentors/mentors.controller.ts
+++ b/src/modules/mentors/mentors.controller.ts
@@ -8,7 +8,7 @@ import { ApplicationDto } from './dto/application.dto';
 import { User, Role } from '../users/interfaces/user.interface';
 import { Application, Status } from './interfaces/application.interface';
 import { UserDto } from '../users/dto/user.dto';
-import EmailService from "../email/email.service";
+import { EmailService } from "../email/email.service";
 
 @ApiUseTags('/mentors')
 @Controller('mentors')
@@ -87,10 +87,9 @@ export class MentorsController {
 
     await this.mentorsService.createApplication(applicationDto);
 
-    // TODO: Move this templateId into a constant
     const emailData = {
       to: user.email,
-      templateId: `d-bf78306901e747a7b3f92761b9884f2e`
+      templateId: EmailService.TEMPLATE_IDS.MENTOR_APPLICATION_RECEIVED,
     };
     
     this.emailService.send(emailData)
@@ -137,10 +136,16 @@ export class MentorsController {
 
     this.usersService.update(userDto);
 
-    // TODO: Move these templateIds into a constant
+    let templateId = null
+    if (applicationDto.status === Status.REJECTED) {
+      templateId = EmailService.TEMPLATE_IDS.MENTOR_APPLICATION_REJECTED
+    } else {
+      EmailService.TEMPLATE_IDS.MENTOR_APPLICATION_APPROVED
+    }
+
     const emailData = {
       to: userDto.email,
-      templateId: applicationDto.status === Status.REJECTED ? `d-ad08366d02654587916a41bb3270afed` : `d-88dc20e5dd164510a32f659f9347824e`
+      templateId,
     };
     
     this.emailService.send(emailData)

--- a/src/modules/mentors/mentors.controller.ts
+++ b/src/modules/mentors/mentors.controller.ts
@@ -8,7 +8,7 @@ import { ApplicationDto } from './dto/application.dto';
 import { User, Role } from '../users/interfaces/user.interface';
 import { Application, Status } from './interfaces/application.interface';
 import { UserDto } from '../users/dto/user.dto';
-import EmailClient from '../../utils/email-client'
+import EmailService from "../email/email.service";
 
 @ApiUseTags('/mentors')
 @Controller('mentors')
@@ -17,6 +17,7 @@ export class MentorsController {
   constructor(
     private readonly mentorsService: MentorsService,
     private readonly usersService: UsersService,
+    private readonly emailService: EmailService,
   ) { }
 
   @ApiOperation({ title: 'Return all mentors in the platform by the given filters' })
@@ -92,7 +93,7 @@ export class MentorsController {
       templateId: `d-bf78306901e747a7b3f92761b9884f2e`
     };
     
-    EmailClient.send(emailData)
+    this.emailService.send(emailData)
 
     return {
       success: true,
@@ -142,7 +143,7 @@ export class MentorsController {
       templateId: applicationDto.status === Status.REJECTED ? `d-ad08366d02654587916a41bb3270afed` : `d-88dc20e5dd164510a32f659f9347824e`
     };
     
-    EmailClient.send(emailData)
+    this.emailService.send(emailData)
 
     return {
       success: res.ok === 1,

--- a/src/modules/mentors/mentors.module.ts
+++ b/src/modules/mentors/mentors.module.ts
@@ -4,6 +4,7 @@ import { MentorsService } from './mentors.service';
 import { UsersModule } from '../users/users.module';
 import { DatabaseModule } from '../../database/database.module';
 import { applicationProviders } from './mentors.providers';
+import { EmailService } from '../email/email.service';
 
 /**
  * Become a mentor module, Endpoints in this module are
@@ -11,8 +12,8 @@ import { applicationProviders } from './mentors.providers';
  * by submiting their profiles for review
  */
 @Module({
-  imports: [DatabaseModule, UsersModule],
+  imports: [DatabaseModule, UsersModule, EmailService],
   controllers: [MentorsController],
-  providers: [MentorsService, ...applicationProviders],
+  providers: [MentorsService, EmailService, ...applicationProviders],
 })
 export class MentorsModule { }

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -6,14 +6,17 @@ import Config from '../../config';
 import { UserDto } from './dto/user.dto';
 import { UsersService } from './users.service';
 import { Role, User } from './interfaces/user.interface';
-import EmailClient from '../../utils/email-client'
+import EmailService from "../email/email.service";
 
 @ApiUseTags('/users')
 @ApiBearerAuth()
 @Controller('users')
 export class UsersController {
 
-  constructor(private readonly usersService: UsersService) { }
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly emailService: EmailService,
+  ) { }
 
   @ApiOperation({ title: 'Return all registered users' })
   @Get()
@@ -55,7 +58,7 @@ export class UsersController {
           templateId: 'd-1434be390e1b4288b8011507f1c8d786',
         };
         
-        EmailClient.send(emailData)
+        this.emailService.send(emailData)
 
         return {
           success: true,

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -49,17 +49,9 @@ export class UsersController {
 
         const newUser: User = await this.usersService.create(userDto);
 
-        // TODO: Move this HTML into SendGrid's templating system
         const emailData = {
           to: userDto.email,
-          subject: 'Welcome to Coding Coach!',
-          html: `<div style="font-family:Verdana,sans-serif;">
-            <h1>Welcome to Coding Coach!</h1>
-            <p style="margin:0 0 32px">Where we are connecting developers with mentors worldwide.</p>
-            <a href="https://mentors.codingcoach.io/" style="border-radius:4px;color:#fff;background:#00bc89;padding:12px 16px;text-decoration:none;">
-              FIND A MENTOR
-            </a>
-            </div>`
+          templateId: 'd-1434be390e1b4288b8011507f1c8d786',
         };
         
         EmailClient.send(emailData)

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -6,6 +6,7 @@ import Config from '../../config';
 import { UserDto } from './dto/user.dto';
 import { UsersService } from './users.service';
 import { Role, User } from './interfaces/user.interface';
+import EmailClient from '../../utils/email-client'
 
 @ApiUseTags('/users')
 @ApiBearerAuth()
@@ -47,6 +48,21 @@ export class UsersController {
         });
 
         const newUser: User = await this.usersService.create(userDto);
+
+        // TODO: Move this HTML into SendGrid's templating system
+        const emailData = {
+          to: userDto.email,
+          subject: 'Welcome to Coding Coach!',
+          html: `<div style="font-family:Verdana,sans-serif;">
+            <h1>Welcome to Coding Coach!</h1>
+            <p style="margin:0 0 32px">Where we are connecting developers with mentors worldwide.</p>
+            <a href="https://mentors.codingcoach.io/" style="border-radius:4px;color:#fff;background:#00bc89;padding:12px 16px;text-decoration:none;">
+              FIND A MENTOR
+            </a>
+            </div>`
+        };
+        
+        EmailClient.send(emailData)
 
         return {
           success: true,

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -6,7 +6,7 @@ import Config from '../../config';
 import { UserDto } from './dto/user.dto';
 import { UsersService } from './users.service';
 import { Role, User } from './interfaces/user.interface';
-import EmailService from "../email/email.service";
+import { EmailService } from "../email/email.service";
 
 @ApiUseTags('/users')
 @ApiBearerAuth()
@@ -52,10 +52,9 @@ export class UsersController {
 
         const newUser: User = await this.usersService.create(userDto);
 
-        // // TODO: Move this templateId into a constant
         const emailData = {
           to: userDto.email,
-          templateId: 'd-1434be390e1b4288b8011507f1c8d786',
+          templateId: EmailService.TEMPLATE_IDS.WELCOME_MESSAGE,
         };
         
         this.emailService.send(emailData)

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -49,6 +49,7 @@ export class UsersController {
 
         const newUser: User = await this.usersService.create(userDto);
 
+        // // TODO: Move this templateId into a constant
         const emailData = {
           to: userDto.email,
           templateId: 'd-1434be390e1b4288b8011507f1c8d786',

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -3,11 +3,12 @@ import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { usersProviders } from './users.providers';
 import { DatabaseModule } from '../../database/database.module';
+import { EmailService } from '../email/email.service';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, EmailService],
   controllers: [UsersController],
-  providers: [UsersService, ...usersProviders],
+  providers: [UsersService, EmailService, ...usersProviders],
   exports: [UsersService, ...usersProviders],
 })
 export class UsersModule { }

--- a/src/utils/email-client/index.ts
+++ b/src/utils/email-client/index.ts
@@ -6,7 +6,7 @@ const defaults = {
     from: 'Coding Coach <no-reply@mail.codingcoach.io>',
 };
 
-
+// TODO: Convert this to a service.
 class EmailFacade {
     constructor() {
         sgMail.setApiKey(Config.sendGrid.API_KEY);

--- a/src/utils/email-client/index.ts
+++ b/src/utils/email-client/index.ts
@@ -19,7 +19,9 @@ class EmailFacade {
     
 }
 
-
+// No point in instantiating this thing more than once, 
+// so it's safe to use a singleton here.  Also freeze the object
+// so it can't be abused later.  👀
 const emailClient = new EmailFacade()
 Object.freeze(emailClient)
 

--- a/src/utils/email-client/index.ts
+++ b/src/utils/email-client/index.ts
@@ -1,0 +1,27 @@
+import Config from '../../config';
+import * as sgMail from '@sendgrid/mail';
+
+
+const defaults = {
+    from: 'Coding Coach <no-reply@mail.codingcoach.io>',
+};
+
+
+class EmailFacade {
+    constructor() {
+        sgMail.setApiKey(Config.sendGrid.API_KEY);
+    }
+    
+    send(data: any) {
+        const newData = Object.assign({}, defaults, data)
+        return sgMail.send(newData);
+    }
+    
+}
+
+
+const emailClient = new EmailFacade()
+Object.freeze(emailClient)
+
+
+export default emailClient

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,12 +69,42 @@
     consola "^2.3.0"
     node-fetch "^2.3.0"
 
+"@sendgrid/client@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-6.4.0.tgz#d58df30adea5d7d09e747e2b61f9f859deeda798"
+  integrity sha512-GcO+hKXMQiwN0xMGfPITArlj4Nab1vZsrsRLmsJlcXGZV1V1zQC6XuAWJv6MGDd0hr/jKaXmCJ1XMYkxIRQHFw==
+  dependencies:
+    "@sendgrid/helpers" "^6.4.0"
+    "@types/request" "^2.0.3"
+    request "^2.88.0"
+
+"@sendgrid/helpers@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-6.4.0.tgz#f9001cbe2f34e2c264d30fcf71aa5b9c3cde49aa"
+  integrity sha512-1dDDXauArHyxwTKFFfWvQpsijmwalyLgwoQJ3FRCssFq1RfqYDgFhRg0Xs3v/IXS2jkKWePSWiPORSR4Sysdpw==
+  dependencies:
+    chalk "^2.0.1"
+    deepmerge "^2.1.1"
+
+"@sendgrid/mail@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-6.4.0.tgz#21d022f7fae57dcdc5910eeca5ed318df21e5f51"
+  integrity sha512-pVzbqbxhZ4FUN6iSIksRLtyXRPurrcee1i0noPDStDCLlHVwUR+TofeeKIFWGpIvbbk5UR6S6iV/U5ie8Kdblw==
+  dependencies:
+    "@sendgrid/client" "^6.4.0"
+    "@sendgrid/helpers" "^6.4.0"
+
 "@types/body-parser@*":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
+
+"@types/caseless@*":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
+  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
 
 "@types/connect@*":
   version "3.4.32"
@@ -151,6 +181,16 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
 
+"@types/request@^2.0.3":
+  version "2.48.2"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.2.tgz#936374cbe1179d7ed529fc02543deb4597450fed"
+  integrity sha512-gP+PSFXAXMrd5PcD7SqHeUjdGshAI8vKQ3+AvpQr3ht9iQea+59LOKvKITcQI+Lg+1EIkDP6AFSBUJPWG8GDyA==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    form-data "^2.5.0"
+
 "@types/serve-static@*":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
@@ -170,6 +210,11 @@
   resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-2.0.7.tgz#46ff6508075cd4519736be060f0d6331a5c8ca7b"
   dependencies:
     "@types/superagent" "*"
+
+"@types/tough-cookie@*":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.5.tgz#9da44ed75571999b65c37b60c9b2b88db54c585d"
+  integrity sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==
 
 abab@^2.0.0:
   version "2.0.0"
@@ -1013,7 +1058,7 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deepmerge@^2.0.1:
+deepmerge@^2.0.1, deepmerge@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
 
@@ -1506,6 +1551,15 @@ forever-agent@~0.6.1:
 form-data@^2.3.1, form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.0.tgz#094ec359dc4b55e7d62e0db4acd76e89fe874d37"
+  integrity sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"


### PR DESCRIPTION
Closes #20

Per our discussions, this PR brings in SendGrid to handle our transactional emails.  

Since email providers have a tendency to change as new players enter the market and new pricing tiers open up, I created a Service through which we should route all email functionality.  This provides a single point of maintenance in the event we need to change providers.

Please review the content and placement of the email invocations.  I'm pretty sure the one for new account creation is in the correct spot, but less certain about the one for approved applications.  

--- 

#### Remaining Tasks

- [x] Actually use TypeScript in the facade.
- [x] Welcome email (for all new user accounts)
- [x] Application received email
- [x] Application rejected email
- [x] Application approved email

---

#### Background on why I chose to create a new template per email

Even though SendGrid allows for dynamic templates, I've found that new transactional emails typically go through a bit of churn before everyone is happy with their design and content.  I did not want to put us in a situation where each iteration on these 4 new email types would require a production push; especially since we lack CI/CD at this point.

Eventually I think we should convert the emails to dynamic templates with the payload kept in the code itself, but I want to give things a few weeks or months so we can let the dust settle.
