### PR TITLE
Add auth0Id to imported mentor on first login

### DIFF
--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -37,33 +37,52 @@ export class UsersController {
     const currentUser: User = await this.usersService.findByAuth0Id(userId);
 
     if (!currentUser) {
-      // If the user doesn't exist in the database we need
-      // to add it because this is a new user. The initial
-      // information is coming from auth0
       try {
         const data: any = await this.getAdminAccessToken();
         const user: any = await this.getUserProfile(data.access_token, userId);
-        const userDto: UserDto = new UserDto({
-          auth0Id: userId,
-          email: user.email,
-          name: user.nickname,
-          avatar: user.picture,
-          roles: [Role.MEMBER],
-        });
 
-        const newUser: User = await this.usersService.create(userDto);
+        // If the user couldn't be found by the auth0Id, try to see whether we
+        // can find one by the email. If so, we have a mentor that was imported
+        // for which we just need to add the auth0Id
+        const existingMentor = await this.usersService.findByEmail(user.email);
+        if (existingMentor) {
+          const userDto: UserDto = new UserDto({
+            _id: existingMentor._id,
+            auth0Id: userId,
+          })
 
-        const emailData = {
-          to: userDto.email,
-          templateId: Template.WELCOME_MESSAGE,
-        };
-        
-        this.emailService.send(emailData)
+          const updatedUser: User = await this.usersService.update(userDto);
 
-        return {
-          success: true,
-          data: newUser,
-        };
+          return {
+            success: true,
+            data: updatedUser,
+          };
+        } else {
+          // If the user doesn't exist in the database we need
+          // to add it because this is a new user. The initial
+          // information is coming from auth0
+          const userDto: UserDto = new UserDto({
+            auth0Id: userId,
+            email: user.email,
+            name: user.nickname,
+            avatar: user.picture,
+            roles: [Role.MEMBER],
+          });
+
+          const newUser: User = await this.usersService.create(userDto);
+
+          const emailData = {
+            to: userDto.email,
+            templateId: Template.WELCOME_MESSAGE,
+          };
+
+          this.emailService.send(emailData)
+
+          return {
+            success: true,
+            data: newUser,
+          };
+        }
       } catch (error) {
         return {
           success: false,

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -20,6 +20,10 @@ export class UsersService {
     return await this.userModel.findOne({ auth0Id }).exec();
   }
 
+  async findByEmail(email: string): Promise<User> {
+    return await this.userModel.findOne({ email }).exec();
+  }
+
   async findAll(): Promise<User[]> {
     return await this.userModel.find().exec();
   }


### PR DESCRIPTION
The first part of #26 was to import the existing mentors into mongo.

The second part was to make sure, to add the auth0Id to the imported mentors on their first login. This pull request fixes the missing part, by linking an imported mentor to the auth0 profile on the first login.