### PR TITLE
Adding approved mentors to marketing list

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/mongoose": "^6.1.2",
     "@nestjs/platform-express": "^6.0.0",
     "@nestjs/swagger": "^3.1.0",
+    "@sendgrid/client": "^6.4.0",
     "@sendgrid/mail": "^6.4.0",
     "class-transformer": "^0.2.3",
     "class-validator": "^0.9.1",

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -1,27 +1,52 @@
 import Config from '../../config';
 import * as sgMail from '@sendgrid/mail';
-import {SendData} from './interfaces/email.interface';
+import * as sgClient from '@sendgrid/client';
+import { SendData } from './interfaces/email.interface';
 import { Injectable } from '@nestjs/common';
+import { User } from '../common/interfaces/user.interface';
 
 const defaults = {
-    from: Config.email.FROM,
+  from: Config.email.FROM,
 };
 
 @Injectable()
 export class EmailService {
-    constructor() {
-        sgMail.setApiKey(Config.sendGrid.API_KEY);
-    }
+  constructor() {
+    sgMail.setApiKey(Config.sendGrid.API_KEY);
+    sgClient.setApiKey(Config.sendGrid.API_KEY);
+  }
 
-    static TEMPLATE_IDS = {
-        WELCOME_MESSAGE: 'd-1434be390e1b4288b8011507f1c8d786',
-        MENTOR_APPLICATION_RECEIVED: 'd-bf78306901e747a7b3f92761b9884f2e',
-        MENTOR_APPLICATION_APPROVED: 'd-88dc20e5dd164510a32f659f9347824e',
-        MENTOR_APPLICATION_REJECTED: 'd-ad08366d02654587916a41bb3270afed',
+  static TEMPLATE_IDS = {
+    WELCOME_MESSAGE: 'd-1434be390e1b4288b8011507f1c8d786',
+    MENTOR_APPLICATION_RECEIVED: 'd-bf78306901e747a7b3f92761b9884f2e',
+    MENTOR_APPLICATION_APPROVED: 'd-88dc20e5dd164510a32f659f9347824e',
+    MENTOR_APPLICATION_REJECTED: 'd-ad08366d02654587916a41bb3270afed',
+  };
+
+  static LIST_IDS = {
+    MENTORS: '3e581cd7-9b14-4486-933e-1e752557433f',
+  };
+
+  async send<TemplateParams>(data: SendData<TemplateParams>) {
+    const newData = Object.assign({}, defaults, data);
+    return await sgMail.send(newData);
+  }
+
+  async addMentor(contact: User) {
+    const request = {
+      json: undefined, // <--- I spent hours finding out why Sendgrid was returning 400 error, this fixed the issue
+      method: 'PUT',
+      url: '/v3/marketing/contacts',
+      body: JSON.stringify({
+        list_ids: [EmailService.LIST_IDS.MENTORS],
+        contacts: [{
+          email: contact.email,
+          first_name: contact.name,
+          country: contact.country,
+        }]
+      }),
     };
-
-    async send<TemplateParams>(data: SendData<TemplateParams>) {
-        const newData = Object.assign({}, defaults, data);
-        return await sgMail.send(newData);
-    }
+    
+    return await sgClient.request(request);
+  }
 }

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -5,9 +5,12 @@ import { SendData } from './interfaces/email.interface';
 import { Injectable } from '@nestjs/common';
 import { User } from '../common/interfaces/user.interface';
 
+const isProduction = process.env.NODE_ENV === 'production';
 const defaults = {
   from: Config.email.FROM,
 };
+
+const DEV_TESTING_LIST = '423467cd-c4bd-410c-ad52-adcd8dfbc389';
 
 @Injectable()
 export class EmailService {
@@ -24,7 +27,9 @@ export class EmailService {
   };
 
   static LIST_IDS = {
-    MENTORS: '3e581cd7-9b14-4486-933e-1e752557433f',
+    // We are adding all dev/testing contacts to a dev list, so we can remove them easly
+    MENTORS: isProduction ? '3e581cd7-9b14-4486-933e-1e752557433f' : DEV_TESTING_LIST,
+    NEWSLETTER: isProduction ? '6df91cab-90bd-4eaa-9710-c3804f8aba01' : DEV_TESTING_LIST,
   };
 
   async send<TemplateParams>(data: SendData<TemplateParams>) {
@@ -43,10 +48,14 @@ export class EmailService {
           email: contact.email,
           first_name: contact.name,
           country: contact.country,
+          custom_fields: {
+            // We can clean our list in SG with this field
+            e2_T: isProduction ? 'production' : 'development'
+          }
         }]
       }),
     };
-    
+
     return await sgClient.request(request);
   }
 }

--- a/src/modules/mentors/mentors.controller.ts
+++ b/src/modules/mentors/mentors.controller.ts
@@ -207,7 +207,12 @@ export class MentorsController {
     };
 
     const res: any = await this.mentorsService.updateApplication(applicationDto);
-    await this.emailService.send<SendDataRejectParams>(emailData);
+    try {
+      await this.emailService.send<SendDataRejectParams>(emailData);
+      await this.emailService.addMentor(user);
+    } catch (error) {
+      console.log(error);
+    }
 
     return {
       success: res.ok === 1,

--- a/src/modules/mentors/mentors.controller.ts
+++ b/src/modules/mentors/mentors.controller.ts
@@ -211,7 +211,7 @@ export class MentorsController {
       await this.emailService.send<SendDataRejectParams>(emailData);
       await this.emailService.addMentor(user);
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
 
     return {


### PR DESCRIPTION
We want to be able to communicate with all our mentors, therefore when approving an application we need to add the email address to the `Mentors` list in sendgrid.

This PR also introduces a try/catch statement for when sendgrid API fails.

Closes #64 