### PR TITLE
Users should not be able to update their email

### DIFF
--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -142,6 +142,7 @@ export class UsersController {
     const userDto: UserDto = new UserDto({
       ...data,
       roles,
+      email: user.email,
       _id: user._id,
     });
     const res: any = await this.usersService.update(userDto);


### PR DESCRIPTION
We are not going to allow users to update their email, this is mainly because we need to keep in sync the email in auth0.

closes #63 