### PR TITLE
Adding filters to the mentors endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dotenv": "^8.0.0",
     "express-jwt": "^5.3.1",
     "i18n-iso-countries": "^4.3.1",
+    "iso-639-1": "^2.1.0",
     "jwks-rsa": "^1.5.0",
     "mongoose": "^5.5.10",
     "reflect-metadata": "^0.1.12",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "class-validator": "^0.9.1",
     "dotenv": "^8.0.0",
     "express-jwt": "^5.3.1",
+    "i18n-iso-countries": "^4.3.1",
     "jwks-rsa": "^1.5.0",
     "mongoose": "^5.5.10",
     "reflect-metadata": "^0.1.12",

--- a/src/modules/common/dto/filter.dto.ts
+++ b/src/modules/common/dto/filter.dto.ts
@@ -1,0 +1,9 @@
+
+export class Filter {
+  readonly id: string;
+  readonly label: string;
+
+  constructor(values) {
+    Object.assign(this, values);
+  }
+}

--- a/src/modules/common/mentors.service.ts
+++ b/src/modules/common/mentors.service.ts
@@ -39,8 +39,7 @@ export class MentorsService {
     }
 
     const countries = await this.userModel.findUniqueCountries(onlyMentors);
-    const languages = await this.userModel.find(onlyMentors)
-      .distinct('spokenLanguages');
+    const languages = await this.userModel.findUniqueLanguages(onlyMentors);
     const technologies = await this.userModel.find(onlyMentors)
       .distinct('tags');
 
@@ -55,7 +54,7 @@ export class MentorsService {
       mentors,
       filters: {
         countries,
-        languages: languages.sort(),
+        languages,
         technologies: technologies.sort(),
       },
     };

--- a/src/modules/common/mentors.service.ts
+++ b/src/modules/common/mentors.service.ts
@@ -16,7 +16,7 @@ export class MentorsService {
    * Search for mentors by the given filters
    * @param filters filters to apply
    */
-  async findAll(filters: MentorFiltersDto, isLoggedIn: boolean): Promise<User[]> {
+  async findAll(filters: MentorFiltersDto, isLoggedIn: boolean) {
     const onlyMentors: any = {
       roles: 'Mentor',
     };
@@ -38,12 +38,27 @@ export class MentorsService {
       onlyMentors.spokenLanguages = filters.spokenLanguages;
     }
 
-    return await this.userModel.find(onlyMentors)
+    const countries = await this.userModel.findUniqueCountries(onlyMentors);
+    const languages = await this.userModel.find(onlyMentors)
+      .distinct('spokenLanguages');
+    const technologies = await this.userModel.find(onlyMentors)
+      .distinct('tags');
+
+    const mentors = await this.userModel.find(onlyMentors)
       .select(projections)
       .skip(filters.offset)
       .limit(filters.perpage)
       .sort({ created_at: 'desc' })
       .exec();
+
+    return {
+      mentors,
+      filters: {
+        countries,
+        languages: languages.sort(),
+        technologies: technologies.sort(),
+      },
+    };
   }
 
   async findApplications(filters): Promise<Application[]> {

--- a/src/modules/common/schemas/user.schema.ts
+++ b/src/modules/common/schemas/user.schema.ts
@@ -1,5 +1,7 @@
 import * as mongoose from 'mongoose';
+import * as countriesDb from 'i18n-iso-countries';
 import { ChannelName } from '../interfaces/user.interface';
+import { Filter } from '../dto/filter.dto';
 
 export const ChannelSchema = new mongoose.Schema({
   type: {
@@ -40,3 +42,20 @@ export const UserSchema = new mongoose.Schema({
 });
 
 UserSchema.set('timestamps', true);
+
+UserSchema.statics.findUniqueCountries = async function (filters): Promise<Array<Filter>> {
+  const result: Array<Filter> = [];
+
+  const countries = await this.find(filters)
+    .distinct('country');
+
+  countries.sort().forEach((id) => {
+    const label = countriesDb.getName(id, 'en');
+
+    if (label) {
+      result.push(new Filter({ id, label }));
+    }
+  });
+
+  return result;
+};

--- a/src/modules/common/schemas/user.schema.ts
+++ b/src/modules/common/schemas/user.schema.ts
@@ -1,5 +1,6 @@
 import * as mongoose from 'mongoose';
 import * as countriesDb from 'i18n-iso-countries';
+import * as languagesDb from 'iso-639-1';
 import { ChannelName } from '../interfaces/user.interface';
 import { Filter } from '../dto/filter.dto';
 
@@ -50,7 +51,25 @@ UserSchema.statics.findUniqueCountries = async function (filters): Promise<Array
     .distinct('country');
 
   countries.sort().forEach((id) => {
-    const label = countriesDb.getName(id, 'en');
+    const label: string = countriesDb.getName(id, 'en');
+
+    if (label) {
+      result.push(new Filter({ id, label }));
+    }
+  });
+
+  return result;
+};
+
+UserSchema.statics.findUniqueLanguages = async function (filters): Promise<Array<Filter>> {
+  const result: Array<Filter> = [];
+
+  const languages = await this.find(filters)
+    .distinct('spokenLanguages');
+
+  languages.sort().forEach((id) => {
+    // @ts-ignore
+    const label: string = languagesDb.getName(id);
 
     if (label) {
       result.push(new Filter({ id, label }));

--- a/src/modules/mentors/mentors.controller.ts
+++ b/src/modules/mentors/mentors.controller.ts
@@ -40,11 +40,12 @@ export class MentorsController {
   @Get()
   @UsePipes(new PaginationPipe())
   async index(@Req() request: Request, @Query() filters: MentorFiltersDto) {
-    const data: User[] = await this.mentorsService.findAll(filters, !!request.user);
+    const data = await this.mentorsService.findAll(filters, !!request.user);
 
     return {
       success: true,
-      data,
+      filters: data.filters,
+      data: data.mentors,
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,6 +1125,11 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
 
+diacritics@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/diacritics/-/diacritics-1.3.0.tgz#3efa87323ebb863e6696cebb0082d48ff3d6f7a1"
+  integrity sha1-PvqHMj67hj5mls67AILUj/PW96E=
+
 dicer@0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
@@ -1834,6 +1839,13 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+i18n-iso-countries@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/i18n-iso-countries/-/i18n-iso-countries-4.3.1.tgz#f110a8824ce14edbb0eb8f3b0bd817ff950af37c"
+  integrity sha512-yxeCvmT8yO1p/epv93c1OHnnYNNMOX6NUNpNfuvzSIcDyripS7OGeKXgzYGd5QI31UK+GBrMG0nPFNv0jrHggw==
+  dependencies:
+    diacritics "^1.3.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2162,6 +2162,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
+iso-639-1@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/iso-639-1/-/iso-639-1-2.1.0.tgz#df88d7dd14b39c4dc748f8b35b6c7ae490e9d543"
+  integrity sha512-8CTinLimb9ncAJ11wpCETWZ51qsQ3LS4vMHF2wxRRtR3+b7bvIxUlXOGYIdq0413+baWnbyG5dBluVcezOG/LQ==
+
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"


### PR DESCRIPTION
Along with the mentors there's a new object containing the filters for the current mentors. The new response looks like this:

```
{
    "success": true,
    "filters": {
        "countries": [{"id": "AR","label": "Argentina"}, ...],
        "languages": [{"id": "en", "label": "English"}, ...],
        "technologies": ["angular", "backend", ...],
     }
     "data": [ .... ]
}
```

The data in the filters object contains unique values for the filtered users in the resultset.

Closes #69 