### PR TITLE
Adding the pagination information to the response

### DIFF
--- a/src/modules/common/dto/filter.dto.ts
+++ b/src/modules/common/dto/filter.dto.ts
@@ -1,5 +1,5 @@
 
-export class Filter {
+export class FilterDto {
   readonly id: string;
   readonly label: string;
 

--- a/src/modules/common/dto/pagination.dto.ts
+++ b/src/modules/common/dto/pagination.dto.ts
@@ -1,6 +1,5 @@
 import { ApiModelPropertyOptional } from '@nestjs/swagger';
 import { IsOptional } from 'class-validator';
-import Config from '../../../config';
 
 export class PaginationDto {
 
@@ -13,4 +12,13 @@ export class PaginationDto {
   readonly perpage: number;
   
   readonly offset: number;
+  
+  readonly total: number;
+  
+  readonly hasMore: boolean;
+
+  constructor(values) {
+    Object.assign(this, values);
+    this.hasMore = (values.offset + values.perpage) < values.total;
+  }
 }

--- a/src/modules/common/mentors.service.ts
+++ b/src/modules/common/mentors.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable } from '@nestjs/common';
 import { Query, Model } from 'mongoose';
 import { MentorFiltersDto } from './dto/mentorfilters.dto';
 import { ApplicationDto } from './dto/application.dto';
+import { FilterDto } from './dto/filter.dto'
+import { PaginationDto } from './dto/pagination.dto';
 import { User } from './interfaces/user.interface';
 import { Application, Status } from './interfaces/application.interface';
 
@@ -38,12 +40,11 @@ export class MentorsService {
       onlyMentors.spokenLanguages = filters.spokenLanguages;
     }
 
-    const countries = await this.userModel.findUniqueCountries(onlyMentors);
-    const languages = await this.userModel.findUniqueLanguages(onlyMentors);
-    const technologies = await this.userModel.find(onlyMentors)
-      .distinct('tags');
-
-    const mentors = await this.userModel.find(onlyMentors)
+    const countries: Array<FilterDto> = await this.userModel.findUniqueCountries(onlyMentors);
+    const languages: Array<FilterDto> = await this.userModel.findUniqueLanguages(onlyMentors);
+    const technologies: Array<FilterDto> = await this.userModel.find(onlyMentors).distinct('tags');
+    const total: number = await this.userModel.find(onlyMentors).countDocuments();
+    const mentors: Array<User> = await this.userModel.find(onlyMentors)
       .select(projections)
       .skip(filters.offset)
       .limit(filters.perpage)
@@ -52,6 +53,11 @@ export class MentorsService {
 
     return {
       mentors,
+      pagination: new PaginationDto({
+        total,
+        page: filters.page,
+        perpage: filters.perpage
+      }),
       filters: {
         countries,
         languages,

--- a/src/modules/common/pipes/pagination.pipe.ts
+++ b/src/modules/common/pipes/pagination.pipe.ts
@@ -5,14 +5,14 @@ import Config from '../../../config';
 export class PaginationPipe implements PipeTransform {
   transform(value: any, metadata: ArgumentMetadata) {
     if (value && metadata.type === 'query') {
-      let page = value.page || 1;
-      let perpage = value.perpage || Config.pagination.perPage;
+      let page = parseInt(value.page, 10);
+      let perpage = parseInt(value.perpage, 10);
 
-      if (page <=0) {
+      if (isNaN(page) || page <=0) {
         page = 1;
       }
       
-      if (perpage <=0) {
+      if (isNaN(perpage) || perpage <=0) {
         perpage = Config.pagination.perPage;
       }
 
@@ -21,7 +21,7 @@ export class PaginationPipe implements PipeTransform {
       return {
         ...value,
         page,
-        perpage: parseInt(perpage, 10),
+        perpage,
         offset,
       };
     }

--- a/src/modules/common/schemas/user.schema.ts
+++ b/src/modules/common/schemas/user.schema.ts
@@ -2,7 +2,7 @@ import * as mongoose from 'mongoose';
 import * as countriesDb from 'i18n-iso-countries';
 import * as languagesDb from 'iso-639-1';
 import { ChannelName } from '../interfaces/user.interface';
-import { Filter } from '../dto/filter.dto';
+import { FilterDto } from '../dto/filter.dto';
 
 export const ChannelSchema = new mongoose.Schema({
   type: {
@@ -44,8 +44,8 @@ export const UserSchema = new mongoose.Schema({
 
 UserSchema.set('timestamps', true);
 
-UserSchema.statics.findUniqueCountries = async function (filters): Promise<Array<Filter>> {
-  const result: Array<Filter> = [];
+UserSchema.statics.findUniqueCountries = async function (filters): Promise<Array<FilterDto>> {
+  const result: Array<FilterDto> = [];
 
   const countries = await this.find(filters)
     .distinct('country');
@@ -54,15 +54,15 @@ UserSchema.statics.findUniqueCountries = async function (filters): Promise<Array
     const label: string = countriesDb.getName(id, 'en');
 
     if (label) {
-      result.push(new Filter({ id, label }));
+      result.push(new FilterDto({ id, label }));
     }
   });
 
   return result;
 };
 
-UserSchema.statics.findUniqueLanguages = async function (filters): Promise<Array<Filter>> {
-  const result: Array<Filter> = [];
+UserSchema.statics.findUniqueLanguages = async function (filters): Promise<Array<FilterDto>> {
+  const result: Array<FilterDto> = [];
 
   const languages = await this.find(filters)
     .distinct('spokenLanguages');
@@ -72,7 +72,7 @@ UserSchema.statics.findUniqueLanguages = async function (filters): Promise<Array
     const label: string = languagesDb.getName(id);
 
     if (label) {
-      result.push(new Filter({ id, label }));
+      result.push(new FilterDto({ id, label }));
     }
   });
 

--- a/src/modules/mentors/mentors.controller.ts
+++ b/src/modules/mentors/mentors.controller.ts
@@ -45,6 +45,7 @@ export class MentorsController {
     return {
       success: true,
       filters: data.filters,
+      pagination: data.pagination,
       data: data.mentors,
     };
   }


### PR DESCRIPTION
This PR introduces a new `pagination` object to the mentors response:

```
{
  success: true,
  "pagination": {
      "total": 281,
      "page": 15,
      "perpage": 20,
      "hasMore": false
  },
  filters: { ... },
  data: [ .... ]
}
```

Closes #75 