### PR TITLE
Don't take image and name from auth0

### DIFF
--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -66,8 +66,6 @@ export class UsersController {
           const userDto: UserDto = new UserDto({
             auth0Id: userId,
             email: user.email,
-            name: user.nickname,
-            avatar: user.picture,
             roles: [Role.MEMBER],
           });
 


### PR DESCRIPTION
Currently, mentors are not changing the default name and image that auth0 created for them.
Instead of validating it in the client, we'll just not take those details for them so they will have to file it.

Make sense?