### PR TITLE
Returning an empty array if no favorites

### DIFF
--- a/src/modules/lists/__tests__/favorites.controller.spec.ts
+++ b/src/modules/lists/__tests__/favorites.controller.spec.ts
@@ -169,5 +169,13 @@ describe('modules/lists/FavoritesController', () => {
       expect(listsService.findFavoriteList).toHaveBeenCalledTimes(1);
       expect(listsService.findFavoriteList).toHaveBeenCalledWith(user);
     });
+
+    it('should return and empty array when there are no favorites', async () => {
+      listsService.findFavoriteList = jest.fn(() => Promise.resolve(undefined));
+
+      expect(await favoritesController.list(request, userId)).toEqual({ success: true, data: [] });
+      expect(listsService.findFavoriteList).toHaveBeenCalledTimes(1);
+      expect(listsService.findFavoriteList).toHaveBeenCalledWith(user);
+    });
   });
 });

--- a/src/modules/lists/favorites.controller.ts
+++ b/src/modules/lists/favorites.controller.ts
@@ -37,7 +37,7 @@ export class FavoritesController {
 
     return {
       success: true,
-      data,
+      data: data || [],
     };
   }
 


### PR DESCRIPTION
This is a bug fix, when a user doesn't have favorites yet, the API is returning null, but it should return an empty array.