### PR TITLE
Upgrade TS from 3.4.3 to 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ts-node": "8.1.0",
     "tsconfig-paths": "3.8.0",
     "tslint": "5.16.0",
-    "typescript": "3.4.3",
+    "typescript": "4.1.2",
     "wait-on": "^3.2.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5456,9 +5456,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
+typescript@3.9.4:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.4.tgz#5aa0a54904b51b96dfd67870ce2db70251802f10"
+  integrity sha512-9OL+r0KVHqsYVH7K18IBR9hhC82YwLNlpSZfQDupGcfg8goB9p/s/9Okcy+ztnTeHR2U68xq21/igW9xpoGTgA==
 
 uglify-js@^3.1.4:
   version "3.5.14"


### PR DESCRIPTION
Looks like It was an easy change.

Tests are passing. TSLint has only one error with `console.log` I guess we can resolve it in a separate PR. Build command throwing no errors. Although, I'm not tested it with the client yet, be able to do this in the next few days.

Resolves #138