### PR TITLE
Fix mentorship request email params

### DIFF
--- a/src/modules/email/interfaces/email.interface.ts
+++ b/src/modules/email/interfaces/email.interface.ts
@@ -26,5 +26,4 @@ export interface SendDataRejectParams {
 export interface SendDataMentorshipParams {
   name: string;
   message: string;
-  reason: string;
 }

--- a/src/modules/mentorships/mentorships.controller.ts
+++ b/src/modules/mentorships/mentorships.controller.ts
@@ -80,8 +80,10 @@ export class MentorshipsController {
       const emailData = {
         to: mentor.email,
         templateId: Template.MENTORSHIP_REQUEST,
-        name: current.name,
-        message: data.message,
+        dynamic_template_data: {
+          name: current.name,
+          message: data.message,
+        },
       };
       await this.emailService.send<SendDataMentorshipParams>(emailData);
     } catch (error) {


### PR DESCRIPTION
The variables should be passed under the `dynamic_template_data` key.