### PR TITLE
Add email templates for mentorship flow.

### DIFF
--- a/content/email_templates/mentorship-accepted.html
+++ b/content/email_templates/mentorship-accepted.html
@@ -1,0 +1,7 @@
+<h1>Mentorship Request Accepted</h1>
+
+<p><b>Congratulations, {{menteeName}}!</b></p>
+
+<p>Your request for mentorship with {{mentorName}} has been approved.</p>
+
+<p>{{mentorName}} asks that you contact them at {{contactURL}} in order to get started.</p>

--- a/content/email_templates/mentorship-rejected.html
+++ b/content/email_templates/mentorship-rejected.html
@@ -1,0 +1,8 @@
+<h1>Mentorship Request Not Accepted</h1>
+
+<p>Unfortunately, your request for mentorship with {{mentorNam}} was not accepted.</p>
+<p>They provided the reason below, which we hope will help you find your next mentor:</p>
+
+<pre>{{reason}}</pre>
+
+<p>Although this one didn't work out, there are many other mentors at <a href="https://mentors.codingcoach.io/">CodingCoach</a> looking to mentor someone like you.</p>

--- a/content/email_templates/mentorship-requested.html
+++ b/content/email_templates/mentorship-requested.html
@@ -1,0 +1,11 @@
+<h1>Mentorship Requested</h1>
+
+<p>Hello!</p>
+
+<p>You have a new mentorship request from {{name}}</p>
+
+<p>Here's a brief message they wanted to share with you:</p>
+
+<pre>{{message}}</pre>
+
+<p>Please check your account to review the full request and respond when you can.  They are as excited as you are to learn everything you have to share!</p>


### PR DESCRIPTION
This PR adds three new email templates to support the mentorship flow.  They are here solely for version control, and will need to be manually copied into our email provider.

---

I think there's a lot more we can and should do with these, but I think this is a decent start.

The only thing I'd consider changing for now is the mentorship request email.  Instead of asking them to check their account, I wonder if it might be more effective to provide all of the text from the request and drop a link into the email that would take the mentor directly to the request in order to approve/deny.  It's not a show stopper in my opinion, but I do think it would bring a lot of value to everyone involved in the process.