### PR TITLE
fix/hide mentor channels when not approved mentorship

### DIFF
--- a/src/modules/common/mentors.service.ts
+++ b/src/modules/common/mentors.service.ts
@@ -97,7 +97,7 @@ export class MentorsService {
       if (user) {
         // find all of their mentorships
         const mentorships: Mentorship[] = await this.mentorshipModel
-          .find({ mentee: user._id })
+          .find({ mentee: user._id, status: Status.APPROVED })
           .exec();
 
         // flatten the mentors into a set

--- a/test/api/mentors.e2e-spec.ts
+++ b/test/api/mentors.e2e-spec.ts
@@ -9,7 +9,11 @@ import {
   Role,
   ChannelName,
 } from '../../src/modules/common/interfaces/user.interface';
-import { createUser, createMentorship } from '../utils/seeder';
+import {
+  createUser,
+  createMentorship,
+  approveMentorship,
+} from '../utils/seeder';
 import { getToken } from '../utils/jwt';
 
 describe('Mentors', () => {
@@ -113,6 +117,8 @@ describe('Mentors', () => {
         mentor: mentor1._id,
         mentee: mentee._id,
       });
+
+      await approveMentorship({ mentorship });
 
       const token = getToken(mentee);
 

--- a/test/utils/seeder.ts
+++ b/test/utils/seeder.ts
@@ -40,3 +40,8 @@ export const createMentorship = ({
     status,
   }).save();
 };
+
+export const approveMentorship = async ({ mentorship }) => {
+  mentorship.status = 'Approved';
+  await mentorship.save();
+};


### PR DESCRIPTION
The requirement is to only show mentor channels only if (s)he is a mentor of the user.
Currently the server return the channels when there is mentorship in any status.

In other words:

1. Go to a mentor profile
2. You can't see their channels
3. Send a mentorship request
4. You can see their channels

The PR aims to show the mentor channels only if there is an **approved** mentorship.