### PR TITLE
feat(mentorship-request): return email in request

### DIFF
--- a/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
+++ b/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
@@ -18,6 +18,7 @@ class ObjectIdMock {
   constructor(current: string) {
     this.current = current;
   }
+
   equals(value) {
     return this.current === value.current;
   }
@@ -265,7 +266,7 @@ describe('modules/mentorships/MentorshipsController', () => {
       expect(response.data[0].isMine).toBe(true);
     });
 
-    it.only("should return unauthorised if user is not admin and requesting another user's applications", async () => {
+    it("should return unauthorised if user is not admin and requesting another user's applications", async () => {
       request = { user: { _id: menteeId, auth0Id: '1234' } };
 
       usersService.findByAuth0Id = jest.fn(() =>

--- a/src/modules/mentorships/mentorships.controller.ts
+++ b/src/modules/mentorships/mentorships.controller.ts
@@ -68,6 +68,10 @@ export class MentorshipsController {
       throw new BadRequestException('Mentor not found');
     }
 
+    if (mentor._id.equals(current._id)) {
+      throw new BadRequestException(`Are you planning to mentor yourself?`);
+    }
+
     if (!mentor.available) {
       throw new BadRequestException('Mentor is not available');
     }
@@ -76,6 +80,7 @@ export class MentorshipsController {
       mentor._id,
       current._id,
     );
+
     if (mentorship) {
       throw new BadRequestException('A mentorship request already exists');
     }
@@ -164,6 +169,7 @@ export class MentorshipsController {
                 name: item.mentee.name,
                 avatar: item.mentee.avatar,
                 title: item.mentee.title,
+                email: item.mentee.email,
               })
             : null,
           mentor: item.mentor

--- a/src/modules/users/__tests__/users.controller.spec.ts
+++ b/src/modules/users/__tests__/users.controller.spec.ts
@@ -268,7 +268,7 @@ describe('modules/users/UsersController', () => {
       const data = new UserDto({
         name: 'Crysfel Villa',
         avatar: 'test.jpg',
-        roles: ['Admin', 'SomethingElse'],
+        roles: [Role.ADMIN, Role.MENTOR],
       });
 
       usersService.findByAuth0Id = jest.fn(() =>
@@ -302,7 +302,7 @@ describe('modules/users/UsersController', () => {
       const data = new UserDto({
         name: 'Crysfel Villa',
         avatar: 'test.jpg',
-        roles: ['Member', 'Admin'],
+        roles: [Role.MEMBER, Role.ADMIN],
       });
 
       usersService.findByAuth0Id = jest.fn(() =>
@@ -336,7 +336,7 @@ describe('modules/users/UsersController', () => {
         name: 'Crysfel Villa',
         email: 'should@ignore.com',
         avatar: 'test.jpg',
-        roles: ['Member', 'Admin'],
+        roles: [Role.MEMBER, Role.ADMIN],
       });
 
       usersService.findByAuth0Id = jest.fn(() =>


### PR DESCRIPTION
This PR aims to add the mentee's email to mentorship so the client can present a link to submit an email to a suppose to be mentee for clarifications.

Related to https://github.com/Coding-Coach/find-a-mentor/issues/790

