### PR TITLE
fix: get specific user

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "nock": "^13.0.5",
     "nodemon": "^1.18.9",
     "prettier": "^2.3.0",
+    "source-map-support": "^0.5.19",
     "supertest": "^3.4.1",
     "ts-jest": "^26.4.4",
     "ts-node": "8.1.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import 'source-map-support/register';
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';
 import { MyLogger } from './logger';

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -4,13 +4,15 @@ import * as jwt from 'express-jwt';
 import { expressJwtSecret } from 'jwks-rsa';
 import Config from '../config';
 
+const secret = expressJwtSecret({
+  cache: true,
+  rateLimit: true,
+  jwksRequestsPerMinute: 5,
+  jwksUri: `https://${Config.auth0.frontend.DOMAIN}/.well-known/jwks.json`,
+});
+
 const middleware = jwt({
-  secret: expressJwtSecret({
-    cache: true,
-    rateLimit: true,
-    jwksRequestsPerMinute: 5,
-    jwksUri: `https://${Config.auth0.frontend.DOMAIN}/.well-known/jwks.json`,
-  }),
+  secret,
   issuer: `https://${Config.auth0.frontend.DOMAIN}/`,
   algorithms: ['RS256'],
 });
@@ -18,35 +20,40 @@ const middleware = jwt({
 /**
  * Public paths that doesn't require authentication
  */
-const publicUrls = ['/mentors', '/mentors/featured'];
+const publicUrls: RegExp[] = [
+  /^\/mentors$/,
+  /^\/mentors\/featured$/,
+  /^\/users\/[^\/]*$/,
+  /^\/avatars\/[^\/]*$/,
+];
+
+const isPublicUrl = (req: Request) =>
+  publicUrls.some((re) => re.test(req.baseUrl));
 
 @Injectable()
 export class AuthMiddleware implements NestMiddleware {
   use(req: Request, res: Response, next: NextFunction) {
-    middleware(req, res, error => {
-      // Adding the user id
+    middleware(req, res, (error) => {
       if (req.user) {
         // @ts-ignore
         req.user.auth0Id = req.user.sub;
       }
-
-      // For public endpoints we don't need to require authentication
-      if (publicUrls.indexOf(req.baseUrl) >= 0) {
+      if (isPublicUrl(req)) {
         next();
-      } else {
-        if (error) {
-          const status = error.status || 401;
-          const message =
-            error.message ||
-            'You need to be authenticated in order to access this resource.';
-
-          return res.status(status).send({
-            success: false,
-            errors: [message],
-          });
-        }
-        next();
+        return;
       }
+      if (error) {
+        const status = error.status || 401;
+        const message =
+          error.message ||
+          'You need to be authenticated in order to access this resource.';
+
+        return res.status(status).send({
+          success: false,
+          errors: [message],
+        });
+      }
+      next();
     });
   }
 }

--- a/src/modules/common/users.service.ts
+++ b/src/modules/common/users.service.ts
@@ -15,7 +15,7 @@ export class UsersService {
 
   async findById(_id: string): Promise<User> {
     if (isObjectId(_id)) {
-      return await this.userModel.findOne({ _id }).exec();
+      return await this.userModel.findOne({ _id }).lean().exec();
     }
 
     return Promise.resolve(null);

--- a/src/modules/users/__tests__/users.controller.spec.ts
+++ b/src/modules/users/__tests__/users.controller.spec.ts
@@ -9,6 +9,7 @@ import { Auth0Service } from '../../common/auth0.service';
 import { FileService } from '../../common/file.service';
 import { UserDto } from '../../common/dto/user.dto';
 import { User, Role } from '../../common/interfaces/user.interface';
+import { MentorshipsService } from '../../mentorships/mentorships.service';
 
 class ServiceMock {}
 
@@ -31,6 +32,7 @@ describe('modules/users/UsersController', () => {
   let auth0Service: Auth0Service;
   let listService: ListsService;
   let fileService: FileService;
+  let mentorshipsService: MentorshipsService;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
@@ -60,6 +62,10 @@ describe('modules/users/UsersController', () => {
           provide: FileService,
           useValue: new ServiceMock(),
         },
+        {
+          provide: MentorshipsService,
+          useValue: new ServiceMock(),
+        },
       ],
     }).compile();
 
@@ -70,6 +76,7 @@ describe('modules/users/UsersController', () => {
     emailService = module.get<EmailService>(EmailService);
     listService = module.get<ListsService>(ListsService);
     fileService = module.get<FileService>(FileService);
+    mentorshipsService = module.get<MentorshipsService>(MentorshipsService);
   });
 
   describe('index', () => {
@@ -163,6 +170,7 @@ describe('modules/users/UsersController', () => {
         _id: 123,
         name: 'Crysfel Villa',
         email: 'test@testing.com',
+        channels: [],
       };
       const response = { success: true, data };
       const request = { user: { auth0Id: '456' } };
@@ -174,6 +182,9 @@ describe('modules/users/UsersController', () => {
         }),
       );
       usersService.findById = jest.fn(() => Promise.resolve(data));
+      mentorshipsService.findMentorshipsByUser = jest.fn(() =>
+        Promise.resolve([]),
+      );
 
       expect(await usersController.show(request, params)).toEqual(response);
       expect(usersService.findById).toHaveBeenCalledTimes(1);
@@ -196,10 +207,18 @@ describe('modules/users/UsersController', () => {
         }),
       );
       usersService.findById = jest.fn(() => Promise.resolve(data));
+      mentorshipsService.findMentorshipsByUser = jest.fn(() =>
+        Promise.resolve([]),
+      );
 
       expect(await usersController.show(request, params)).toEqual({
         success: true,
-        data: { _id: 123, name: 'Crysfel Villa' },
+        data: {
+          _id: 123,
+          name: 'Crysfel Villa',
+          channels: [],
+          email: undefined,
+        },
       });
       expect(usersService.findById).toHaveBeenCalledTimes(1);
       expect(usersService.findById).toHaveBeenCalledWith(params.id);

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -160,17 +160,17 @@ export class UsersController {
   @ApiImplicitParam({ name: 'id', description: 'The user _id' })
   @Get(':id')
   async show(@Req() request, @Param() params) {
-    const [current, { channels, email, ...user }]: [User, User] =
-      await Promise.all([
-        request.user
-          ? this.usersService.findByAuth0Id(request.user.auth0Id)
-          : Promise.resolve(null),
-        this.usersService.findById(params.id),
-      ]);
+    const [current, requestedUser]: [User, User] = await Promise.all([
+      request.user
+        ? this.usersService.findByAuth0Id(request.user.auth0Id)
+        : Promise.resolve(null),
+      this.usersService.findById(params.id),
+    ]);
 
-    if (!user) {
+    if (!requestedUser) {
       throw new BadRequestException('User not found');
     }
+    const { channels, email, ...user } = requestedUser;
 
     let showChannels = false;
     if (current) {

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -7,10 +7,17 @@ import { MentorsService } from '../common/mentors.service';
 import { ListsModule } from '../lists/lists.module';
 import { ListsService } from '../lists/lists.service';
 import { EmailService } from '../email/email.service';
+import { MentorshipsService } from '../mentorships/mentorships.service';
 
 @Module({
   imports: [DatabaseModule, EmailService, CommonModule, ListsModule],
   controllers: [UsersController],
-  providers: [MentorsService, UsersService, EmailService, ListsService],
+  providers: [
+    MentorsService,
+    UsersService,
+    EmailService,
+    ListsService,
+    MentorshipsService,
+  ],
 })
 export class UsersModule {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5639,6 +5639,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.19:
+  version "0.5.19"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@^0.5.6:
   version "0.5.12"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"


### PR DESCRIPTION
This PR aims to fix the "get current user" method so it will be public and return the right format.

This feature opens the door to the following features

1. To allow every user profile page, not just mentors 
2. To allow to land on a profile page without landing on the mentors list first
3. To allow retrieving more data in profile page than the mentor card in the mentors list (such as longer list of technologies, recommendations etc.)