### PR TITLE
fix: limit mentees' mentorship requests to N

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -32,6 +32,7 @@ const config = {
   pagination: {
     limit: 20,
   },
+  maximumOpenMentorships: 5,
 };
 
 export default config;

--- a/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
+++ b/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
@@ -129,7 +129,7 @@ describe('modules/mentorships/MentorshipsController', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should return a 400 error if a mentee has already requested N mentorships', async () => {
+    it(`should return a 400 error if a mentee requested more mentorships than limit`, async () => {
       const mentorships = [];
       for (let i = 0; i < Config.maximumOpenMentorships + 1; i++) {
         mentorships.push(<Mentorship>{ _id: new ObjectIdMock(i.toString()) });

--- a/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
+++ b/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
@@ -127,7 +127,7 @@ describe('modules/mentorships/MentorshipsController', () => {
 
     it('should return a 400 error if a mentee has already requested N mentorships', async () => {
       const mentorships = [];
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < 6; i++) {
         mentorships.push(<Mentorship>{ _id: new ObjectIdMock(i.toString()) });
       }
       mentorshipsService.getMenteeMentorshipsByStatus = jest.fn(() =>

--- a/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
+++ b/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
@@ -131,7 +131,7 @@ describe('modules/mentorships/MentorshipsController', () => {
 
     it(`should return a 400 error if a mentee requested more mentorships than limit`, async () => {
       const mentorships = [];
-      for (let i = 0; i < Config.maximumOpenMentorships + 1; i++) {
+      for (let i = 0; i < Config.maximumOpenMentorships; i++) {
         mentorships.push(<Mentorship>{ _id: new ObjectIdMock(i.toString()) });
       }
       mentorshipsService.getMenteeMentorshipsByStatus = jest.fn(() =>
@@ -149,7 +149,7 @@ describe('modules/mentorships/MentorshipsController', () => {
         mentorship,
       );
       expect(data.success).toBe(true);
-      expect(data.remaining_mentorships).toEqual('5');
+      expect(data.remaining_mentorships).toEqual('4');
     });
 
     it('should return mentorship requests for a given mentor', async () => {

--- a/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
+++ b/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
@@ -137,9 +137,19 @@ describe('modules/mentorships/MentorshipsController', () => {
       mentorshipsService.getMenteeMentorshipsByStatus = jest.fn(() =>
         Promise.resolve(mentorships),
       );
-      await expect(
-        mentorshipsController.applyForMentorship(request, '123', mentorship),
-      ).rejects.toThrow(BadRequestException);
+      const expectedException = new BadRequestException(
+        `mentees pending/open mentorships request are limited to 5`,
+      );
+      expect.assertions(1);
+      try {
+        await mentorshipsController.applyForMentorship(
+          request,
+          '123',
+          mentorship,
+        );
+      } catch (e) {
+        expect(e.message).toStrictEqual(expectedException.message);
+      }
     });
 
     it('should return a successful response', async () => {

--- a/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
+++ b/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
@@ -125,6 +125,19 @@ describe('modules/mentorships/MentorshipsController', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
+    it('should return a 400 error if a mentee has already requested N mentorships', async () => {
+      const mentorships = [];
+      for (let i = 0; i < 5; i++) {
+        mentorships.push(<Mentorship>{ _id: new ObjectIdMock(i.toString()) });
+      }
+      mentorshipsService.getMenteeMentorshipsByStatus = jest.fn(() =>
+        Promise.resolve(mentorships),
+      );
+      await expect(
+        mentorshipsController.applyForMentorship(request, '123', mentorship),
+      ).rejects.toThrow(BadRequestException);
+    });
+
     it('should return a successful response', async () => {
       const data = await mentorshipsController.applyForMentorship(
         <Request>request,

--- a/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
+++ b/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
@@ -149,6 +149,7 @@ describe('modules/mentorships/MentorshipsController', () => {
         mentorship,
       );
       expect(data.success).toBe(true);
+      expect(data.remaining_mentorships).toEqual('5');
     });
 
     it('should return mentorship requests for a given mentor', async () => {

--- a/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
+++ b/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
@@ -94,6 +94,9 @@ describe('modules/mentorships/MentorshipsController', () => {
       mentorshipsService.createMentorship = jest.fn(() =>
         Promise.resolve(null),
       );
+      mentorshipsService.getMenteeMentorshipsByStatus = jest.fn(() =>
+        Promise.resolve([]),
+      );
       emailService.sendLocalTemplate = jest.fn(() => Promise.resolve(null));
     });
 

--- a/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
+++ b/src/modules/mentorships/__tests__/mentorships.controller.spec.ts
@@ -9,6 +9,7 @@ import { MentorshipsService } from '../mentorships.service';
 import { Role, User } from '../../common/interfaces/user.interface';
 import { MentorshipDto } from '../dto/mentorship.dto';
 import { Mentorship, Status } from '../interfaces/mentorship.interface';
+import Config from '../../../config';
 
 class ServiceMock {}
 
@@ -127,7 +128,7 @@ describe('modules/mentorships/MentorshipsController', () => {
 
     it('should return a 400 error if a mentee has already requested N mentorships', async () => {
       const mentorships = [];
-      for (let i = 0; i < 6; i++) {
+      for (let i = 0; i < Config.maximumOpenMentorships + 1; i++) {
         mentorships.push(<Mentorship>{ _id: new ObjectIdMock(i.toString()) });
       }
       mentorshipsService.getMenteeMentorshipsByStatus = jest.fn(() =>

--- a/src/modules/mentorships/mentorships.controller.ts
+++ b/src/modules/mentorships/mentorships.controller.ts
@@ -132,6 +132,7 @@ export class MentorshipsController {
 
     return {
       success: true,
+      data: `mentees pending/open mentorships' request are limited to ${Config.maximumOpenMentorships}`,
     };
   }
 

--- a/src/modules/mentorships/mentorships.controller.ts
+++ b/src/modules/mentorships/mentorships.controller.ts
@@ -36,6 +36,7 @@ import { Mentorship, Status } from './interfaces/mentorship.interface';
 import { FindOneParams } from '../common/dto/findOneParams.dto';
 import { MentorshipUpdatePayload } from './dto/mentorshipUpdatePayload.dto';
 import { mentorshipsToDtos } from './mentorshipsToDto';
+import Config from '../../config';
 
 @ApiUseTags('/mentorships')
 @Controller('mentorships')
@@ -90,7 +91,10 @@ export class MentorshipsController {
         Status.NEW,
         Status.VIEWED,
       ]);
-    if (newMentorships && newMentorships.length > 5) {
+    if (
+      newMentorships &&
+      newMentorships.length > Config.maximumOpenMentorships
+    ) {
       throw new BadRequestException('A mentee can have only 5  mentorship');
     }
 

--- a/src/modules/mentorships/mentorships.controller.ts
+++ b/src/modules/mentorships/mentorships.controller.ts
@@ -85,7 +85,7 @@ export class MentorshipsController {
       throw new BadRequestException('A mentorship request already exists');
     }
 
-    // before creating a new mentorship, check if the mentee has already 3 mentorship in NEW status
+    // check if the mentee has already Config.maximumOpenMentorships mentorships in NEW or VIEWED status
     const newMentorships: Mentorship[] =
       await this.mentorshipsService.getMenteeMentorshipsByStatus(current._id, [
         Status.NEW,
@@ -93,10 +93,10 @@ export class MentorshipsController {
       ]);
     if (
       newMentorships &&
-      newMentorships.length > Config.maximumOpenMentorships
+      newMentorships.length + 1 > Config.maximumOpenMentorships // +1 as we are attempting to create a mentorship
     ) {
       throw new BadRequestException(
-        `A mentee can have only ${Config.maximumOpenMentorships}  mentorship`,
+        `mentees pending/open mentorships request are limited to ${Config.maximumOpenMentorships}`,
       );
     }
 
@@ -133,7 +133,9 @@ export class MentorshipsController {
     return {
       success: true,
       remaining_mentorships: (
-        Config.maximumOpenMentorships - newMentorships.length
+        Config.maximumOpenMentorships -
+        newMentorships.length -
+        1
       ).toString(),
     };
   }

--- a/src/modules/mentorships/mentorships.controller.ts
+++ b/src/modules/mentorships/mentorships.controller.ts
@@ -1,17 +1,16 @@
-import { UserDto } from './../common/dto/user.dto';
 import {
-  Body,
   BadRequestException,
-  NotFoundException,
+  Body,
   Controller,
+  Get,
+  NotFoundException,
   Param,
   Post,
+  Put,
   Req,
+  UnauthorizedException,
   UsePipes,
   ValidationPipe,
-  Get,
-  Put,
-  UnauthorizedException,
 } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
 import {
@@ -83,6 +82,16 @@ export class MentorshipsController {
 
     if (mentorship) {
       throw new BadRequestException('A mentorship request already exists');
+    }
+
+    // before creating a new mentorship, check if the mentee has already 3 mentorship in NEW status
+    const newMentorships: Mentorship[] =
+      await this.mentorshipsService.getMenteeMentorshipsByStatus(current._id, [
+        Status.NEW,
+        Status.VIEWED,
+      ]);
+    if (newMentorships && newMentorships.length > 5) {
+      throw new BadRequestException('A mentee can have only 5  mentorship');
     }
 
     await this.mentorshipsService.createMentorship({

--- a/src/modules/mentorships/mentorships.controller.ts
+++ b/src/modules/mentorships/mentorships.controller.ts
@@ -132,7 +132,9 @@ export class MentorshipsController {
 
     return {
       success: true,
-      data: `mentees pending/open mentorships' request are limited to ${Config.maximumOpenMentorships}`,
+      remaining_mentorships: (
+        Config.maximumOpenMentorships - newMentorships.length
+      ).toString(),
     };
   }
 

--- a/src/modules/mentorships/mentorships.controller.ts
+++ b/src/modules/mentorships/mentorships.controller.ts
@@ -95,7 +95,9 @@ export class MentorshipsController {
       newMentorships &&
       newMentorships.length > Config.maximumOpenMentorships
     ) {
-      throw new BadRequestException('A mentee can have only 5  mentorship');
+      throw new BadRequestException(
+        `A mentee can have only ${Config.maximumOpenMentorships}  mentorship`,
+      );
     }
 
     await this.mentorshipsService.createMentorship({

--- a/src/modules/mentorships/mentorships.service.ts
+++ b/src/modules/mentorships/mentorships.service.ts
@@ -1,6 +1,6 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { Query, Model, Types } from 'mongoose';
-import { Mentorship } from './interfaces/mentorship.interface';
+import { Mentorship, Status } from './interfaces/mentorship.interface';
 import { MentorshipDto } from './dto/mentorship.dto';
 import { isObjectId } from '../../utils/objectid';
 
@@ -42,6 +42,25 @@ export class MentorshipsService {
    */
   async getAllMentorships() {
     return this.mentorshipModel.find({}).populate('mentee').populate('mentor');
+  }
+
+  /**
+   * Returns all mentorship by mentee by Mentorship status
+   */
+  // todo need to test this!
+  async getMenteeMentorshipsByStatus(
+    menteeId: string,
+    statuses: Status[],
+  ): Promise<Mentorship[]> {
+    if (!isObjectId(menteeId)) {
+      throw new BadRequestException('menteeId is not an objectId');
+    }
+    return this.mentorshipModel
+      .find({
+        mentee: menteeId,
+        status: { $in: statuses },
+      })
+      .exec();
   }
 
   /**

--- a/src/modules/mentorships/mentorships.service.ts
+++ b/src/modules/mentorships/mentorships.service.ts
@@ -47,7 +47,6 @@ export class MentorshipsService {
   /**
    * Returns all mentorship by mentee by Mentorship status
    */
-  // todo need to test this!
   async getMenteeMentorshipsByStatus(
     menteeId: string,
     statuses: Status[],

--- a/test/api/mentorships.e2e-spec.ts
+++ b/test/api/mentorships.e2e-spec.ts
@@ -275,9 +275,9 @@ describe('Mentorships', () => {
         ]);
 
         for (let i = 0; i < Config.maximumOpenMentorships; i++) {
-          const mentorshipStatus = Status.NEW;
+          let mentorshipStatus = Status.NEW;
           if (i % 2) {
-            status = Status.VIEWED;
+            mentorshipStatus = Status.VIEWED;
           }
           const [aMentor] = await Promise.all([createUser()]);
           await createMentorship({

--- a/test/api/mentorships.e2e-spec.ts
+++ b/test/api/mentorships.e2e-spec.ts
@@ -280,7 +280,7 @@ describe('Mentorships', () => {
             status = Status.VIEWED;
           }
           await createMentorship({
-            mentor: faker.random.uuid(),
+            mentor: createUser()._id,
             mentee: mentee._id,
             status: mentorshipStatus,
           });

--- a/test/api/mentorships.e2e-spec.ts
+++ b/test/api/mentorships.e2e-spec.ts
@@ -288,12 +288,14 @@ describe('Mentorships', () => {
         }
 
         const token = getToken(mentee);
-        const { body } = await request(server)
+        const response = await request(server)
           .post(`/mentorships/${mentor._id}/apply`)
           .set('Authorization', `Bearer ${token}`)
           .send(mentorshipData)
           .expect(400);
         // todo: assert over the error message?
+        expect(response.body).toEqual('');
+        expect(response.text).toEqual('');
       });
     });
 
@@ -318,12 +320,14 @@ describe('Mentorships', () => {
         }
 
         const token = getToken(mentee);
-        const { body } = await request(server)
+        const response = await request(server)
           .post(`/mentorships/${mentor._id}/apply`)
           .set('Authorization', `Bearer ${token}`)
           .send(mentorshipData)
           .expect(200);
         // todo: assert over the success message?
+        expect(response.body).toEqual('');
+        expect(response.text).toEqual('');
       });
 
       it('returns a status code of 200 if the current mentee has never requested a mentorship', async () => {
@@ -333,12 +337,14 @@ describe('Mentorships', () => {
         ]);
 
         const token = getToken(mentee);
-        const { body } = await request(server)
+        const response = await request(server)
           .post(`/mentorships/${mentor._id}/apply`)
           .set('Authorization', `Bearer ${token}`)
           .send(mentorshipData)
           .expect(200);
         // todo: assert over the success message?
+        expect(response.body).toEqual('');
+        expect(response.text).toEqual('');
       });
     });
   });

--- a/test/api/mentorships.e2e-spec.ts
+++ b/test/api/mentorships.e2e-spec.ts
@@ -279,8 +279,9 @@ describe('Mentorships', () => {
           if (i % 2) {
             status = Status.VIEWED;
           }
+          const [aMentor] = await Promise.all([createUser()]);
           await createMentorship({
-            mentor: createUser()._id,
+            mentor: aMentor._id,
             mentee: mentee._id,
             status: mentorshipStatus,
           });


### PR DESCRIPTION
**Issue**: https://github.com/Coding-Coach/find-a-mentor-api/issues/206

**What is this change?**:
 
Mentee's mentorships requests will be limited to `N` (as defined in [config file](https://github.com/Coding-Coach/find-a-mentor-api/pull/219/files#diff-198a1431d7c5e26ea78bc6e54b34b54e6f8ab342dd48ea11013877e8466a87c5R35)). 
When a mentee applies for a new mentorship to any mentor, we look at the mentorships in NEW and VIEWED status and we reject the request if `total_requests+1 >= N`

**How was it tested?**:

Unittests (only, for now)

**What improvements are still needed to the PR?**:

I've tried to test the endpoint manually by starting the api using the docker compose file provided. 
The `docker compose `successfully stands us the API & Mongo on `localhost:3000`, but I'm finding the following blockers:

1. I want to use the following curl command to create a mentoship relation in the DB 
   ```
    curl -H "Content-Type: application/json" \ 
    -d '{"status": "NEW", "message": "hello", "goals": ["ahahs"],"expectation": "asjasj", "background": "asasas","reason":"asasas"}' \
    -X POST http://localhost:3000/mentorships/<mentor_id_from_mongo>/apply
    ```
However I'm blocked on how to create user in the DB as I'd need the `<mentee_id_from_mongo>` in the URL
Is there an API for this?  I seem to not find any `post` or create user looking at the swagger :  https://api-staging.codingcoach.io/#/%2Fusers

1. I've tried to run the `e2e tests` from within the api container 
    ```
    docker exec -it find-a-mentor-api yarn:test e2e 
    
    yarn run v1.22.5
    $ jest --verbose --runInBand --config ./test/jest-e2e.json
    Determining test suites to run...Starting the instance failed, please enable debug for more infomation
    Error: Spawned Mongo Instance PID is undefined
        at MongoInstance._launchMongod (/usr/src/node_modules/mongodb-memory-server-core/lib/util/MongoInstance.js:281:19)
        at MongoInstance.<anonymous> (/usr/src/node_modules/mongodb-memory-server-core/lib/util/MongoInstance.js:161:50)
        at step (/usr/src/node_modules/mongodb-memory-server-core/lib/util/MongoInstance.js:44:23)
        at Object.next (/usr/src/node_modules/mongodb-memory-server-core/lib/util/MongoInstance.js:25:53)
        at fulfilled (/usr/src/node_modules/mongodb-memory-server-core/lib/util/MongoInstance.js:16:58)
    error Command failed with exit code 1.
    ```

But with no success, as my experience with JS tooling _is very limited_, any pointers of how I'm supposed to run those tests?

*Side Note:* 

1. Following the steps in [CONTRIBUTING](https://github.com/Coding-Coach/find-a-mentor-api/blob/master/CONTRIBUTING.md#setting-up-vendors) It seems I can't set up Auth0 correctly. 
      Experiencing the following error for all private endpoints , ie
    ```
     curl http://localhost:3000
     {"success":false,"errors":["No authorization token was found"]}%
     
     curl http://localhost:3000/current                                                                                                     
     {"success":false,"errors":["No authorization token was found"]}%
     ``` 
     
   As I don't have experience on Auth0 I've didn't spend too much time debugging the issue, and just made (for testing purposes on my local machine) all endpoint public (by modifying the middleware func) but still in the request the [auth0 subs aren't passed](https://github.com/Coding-Coach/find-a-mentor-api/blob/main/src/modules/mentorships/mentorships.controller.ts#L63) 
   
Thank you for any help!