### PR TITLE
Add a validation condition to show the reason if it is filled.

### DIFF
--- a/content/email_templates/mentorship-declined.html
+++ b/content/email_templates/mentorship-declined.html
@@ -40,11 +40,15 @@
     <span style="font-weight: bold; font-style: italic"><%= mentorName %></span>
     was not accepted.
   </p>
-  <p>
-    They provided the reason below, which we hope will help you find your next
-    mentor:
-  </p>
-  <pre><%= reason %></pre>
+  
+    <% if (reason) { %>
+    <p>
+      They provided the reason below, which we hope will help you find your next
+      mentor:
+    </p>
+    <pre><%= reason %></pre>
+    <% } %>
+
   <% } %>
 
   <p>


### PR DESCRIPTION
Hi @moshfeu and @crysfel,
- I could add a condition in the template file to check if there is a value in the reason to only in this case show the reason.
It is a small fix, however, I couldn´t test it in my environment locally because I`m waiting for SendGrid registration account confirmation check.

So, I need to wait SendGrid to get back to me to get the API key to be able to test the whole flow with this fix.
But, if anyone has the local or staging environment up and running to test it, feel free to do so.
